### PR TITLE
Added Delimiters 

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,9 +1,9 @@
 use crate::parser::tokenizer::Token;
+
 pub fn split_till_plus(vec: &Vec<Token>) -> Result<Vec<Vec<Token>>, String> {
     let mut split: Vec<Vec<Token>> = Vec::new();
-    let vec = delim_token(vec);
     let mut option_depth: i32 = 0;
-    
+
     for (idx, value) in vec.iter().enumerate() {
         match *value {
             Token::Plus => {
@@ -27,66 +27,27 @@ pub fn split_till_plus(vec: &Vec<Token>) -> Result<Vec<Vec<Token>>, String> {
     split.push(vec[..].to_vec());
     Ok(split)
 }
-/// delim_token converts delimed elements in token array
-/// back to the original text form
-/// [Text("shift"), Plus, TokenDelimiters, Plus] -> [Text("shift"), Plus, Text("plus")]
-pub fn delim_token(vec: &Vec<Token>) -> Vec<Token> {
-    let mut skipnext = false;
-    let mut ret:Vec<Token>= Vec::new();
-    for(idx, value) in vec.iter().enumerate(){
-        if skipnext {
-            skipnext = false;
-            continue;
-        }
-        else{
-            match value{
-                Token::Delimiters=> {
-                    let  newstring:Result<Token,&str>={
-                        if vec.len() <= idx+1 {
-                            Err("Using backslash at end of keybinding is invalid")
-                        }
-                        else{
-                            match &vec[idx+1]{
-                                Token::OptionStart => Ok(Token::Text("bracketleft".to_string())),
-                                Token::RangeSeparator => Ok(Token::Text("minus".to_string())),
-                                Token::Comma => Ok(Token::Text("comma".to_string())),
-                                Token::OptionEnd => Ok(Token::Text("bracketright".to_string())),
-                                Token::Plus => Ok(Token::Text("optionplus".to_string())),
-                                Token::Delimiters => Ok(Token::Text("backslash".to_string())),
-                                Token::Text(_) => Err("Using a backslash with regular is invalid"),
-                            }
-                        }
-                    };
-                    ret.push(newstring.unwrap());
-                    skipnext = true;
-                    
-                },
-                Token::OptionStart=>ret.push(Token::OptionStart),
-                Token::RangeSeparator=>ret.push(Token::RangeSeparator),
-                Token::Comma=>ret.push(Token::Comma),
-                Token::OptionEnd=>ret.push(Token::OptionEnd),
-                Token::Plus=>ret.push(Token::Plus),
-                Token::Text(x)=>ret.push(Token::Text(x.to_string())),
-            }
-        }
-    }
-    return ret;
-}
+
 pub fn lex(vec: &Vec<Token>) -> Result<Vec<LexNode>, String> {
     let mut result: Vec<LexNode> = Vec::new();
+
     let split_result = split_till_plus(vec);
+
     let parts = match split_result {
         Ok(parts) => parts,
         Err(error) => return Err(error)
     };
+
     for (_, part) in parts.iter().enumerate() {
         match lex_part(part) {
             Ok(node) => result.push(node),
             Err(err) => return Err(err)
         }
     }
+
     Ok(result)
 }
+
 fn lex_part(vec: &Vec<Token>) -> Result<LexNode, String> {
     if vec.len() == 0 {
         return Err(String::from("lex_part: vector size is 0"));
@@ -515,24 +476,9 @@ mod tests {
                 ])
             }
         ];
+
         assert!(nodes.is_err() == false, "{:?}", nodes.unwrap());
-        let unwrapped = nodes.unwrap();
-        assert_eq!(unwrapped, expected);
-    }
-    #[test]
-    fn test_delim(){
-        let nodes = lex(&tokenize(&String::from("y + \\+ + \\- + \\{ + \\} + \\, + \\\\ + x")));
-        let expected = [
-            LexNode{of_type: LexItem::Text(String::from("y")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("optionplus")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("minus")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("bracketleft")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("bracketright")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("comma")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("backslash")), content: None},
-            LexNode{of_type: LexItem::Text(String::from("x")), content: None}
-        ];
-        assert!(nodes.is_err() == false);
+
         let unwrapped = nodes.unwrap();
         assert_eq!(unwrapped, expected);
     }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -81,22 +81,6 @@ fn lex_part(vec: &Vec<Token>) -> Result<LexNode, String> {
                 return Err(String::from("No matching ending brace (}) to a starting brace ({)"))
             }
         }
-        Token::TokenDelimter =>{
-            // println!("{:?}", vec);
-            let newstring = match &vec[1]{
-                Token::OptionStart=> Ok("bracketleft"),
-                Token::RangeSeparator => Ok("minus"),
-                Token::Comma => Ok("comma"),
-                Token::OptionEnd => Ok("bracketright"),
-                Token::Plus => Ok("optionplus"),
-                Token::TokenDelimter => Ok("backslash"),
-                Token::Text(x) => Err("Using a backslash with backslash is pretty dumb")
-            };
-            // return Err(format!("{:?}", newstring));
-            let mut tmp: Vec<Token> = Vec::new();
-            tmp.push(Token::Text(newstring.unwrap().to_string()));
-            return lex_part(&tmp);
-        }
         _ => return Err(format!("Bad expression! {:?}\nFull vector:\n{:?}", token, vec))
     }
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -81,6 +81,22 @@ fn lex_part(vec: &Vec<Token>) -> Result<LexNode, String> {
                 return Err(String::from("No matching ending brace (}) to a starting brace ({)"))
             }
         }
+        Token::TokenDelimter =>{
+            // println!("{:?}", vec);
+            let newstring = match &vec[1]{
+                Token::OptionStart=> Ok("bracketleft"),
+                Token::RangeSeparator => Ok("minus"),
+                Token::Comma => Ok("comma"),
+                Token::OptionEnd => Ok("bracketright"),
+                Token::Plus => Ok("optionplus"),
+                Token::TokenDelimter => Ok("backslash"),
+                Token::Text(x) => Err("Using a backslash with backslash is pretty dumb")
+            };
+            // return Err(format!("{:?}", newstring));
+            let mut tmp: Vec<Token> = Vec::new();
+            tmp.push(Token::Text(newstring.unwrap().to_string()));
+            return lex_part(&tmp);
+        }
         _ => return Err(format!("Bad expression! {:?}\nFull vector:\n{:?}", token, vec))
     }
 }

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -6,7 +6,6 @@ pub enum Token {
     OptionEnd,
     Plus,
     Text(String),
-    Delimiters,
     //Whitespace
 }
 
@@ -47,10 +46,6 @@ pub fn tokenize(input: &String) -> Vec<Token> {
             '-' => {
                 push_text(&mut text, &mut result);
                 result.push(Token::RangeSeparator)
-            }
-            '\\' =>{
-                push_text(&mut text, &mut result);
-                result.push(Token::Delimiters)
             }
             a => {
                 text.push(a);

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -47,6 +47,22 @@ pub fn tokenize(input: &String) -> Vec<Token> {
                 push_text(&mut text, &mut result);
                 result.push(Token::RangeSeparator)
             }
+            '\\' => {
+                it.next();
+                let result = match it.peek(){
+                    Some('{') =>  Ok('{') ,
+                    Some('}') =>  Ok('}') ,
+                    Some(',') =>  Ok(','),
+                    Some('+') =>  Ok('+'),
+                    Some('-') =>  Ok('-') ,
+                    Some('\\') => Ok('\\') ,
+                    None =>       Err(String::from("Delim cannot be last character")),
+                    _ =>          Err(String::from(format!("Character \\{} is not valid", it.peek().unwrap())))
+                    
+                };
+                text.push(result.unwrap());
+            }
+
             a => {
                 text.push(a);
             }
@@ -120,4 +136,23 @@ mod tests {
 
         assert_eq!(tokens, expected);
     }
+    #[test]
+    fn test_delim(){
+        let tokens = tokenize(&String::from("\\+ +  \\- - \\, , \\{ { \\} } \\\\"));
+        let expected = [
+            Token::Text(String::from("+")),
+            Token::Plus,
+            Token::Text(String::from("-")),
+            Token::RangeSeparator,
+            Token::Text(String::from(",")),
+            Token::Comma,
+            Token::Text(String::from("{")),
+            Token::OptionStart,
+            Token::Text(String::from("}")),
+            Token::OptionEnd,
+            Token::Text(String::from("\\"))
+        ];
+        assert_eq!(tokens, expected);
+    }
+
 }

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -6,6 +6,7 @@ pub enum Token {
     OptionEnd,
     Plus,
     Text(String),
+    TokenDelimter
     //Whitespace
 }
 
@@ -46,6 +47,10 @@ pub fn tokenize(input: &String) -> Vec<Token> {
             '-' => {
                 push_text(&mut text, &mut result);
                 result.push(Token::RangeSeparator)
+            }
+            '\\' =>{
+                push_text(&mut text, &mut result);
+                result.push(Token::TokenDelimter)
             }
             a => {
                 text.push(a);

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -6,7 +6,6 @@ pub enum Token {
     OptionEnd,
     Plus,
     Text(String),
-    TokenDelimter
     //Whitespace
 }
 
@@ -47,10 +46,6 @@ pub fn tokenize(input: &String) -> Vec<Token> {
             '-' => {
                 push_text(&mut text, &mut result);
                 result.push(Token::RangeSeparator)
-            }
-            '\\' =>{
-                push_text(&mut text, &mut result);
-                result.push(Token::TokenDelimter)
             }
             a => {
                 text.push(a);

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -6,6 +6,7 @@ pub enum Token {
     OptionEnd,
     Plus,
     Text(String),
+    Delimiters,
     //Whitespace
 }
 
@@ -46,6 +47,10 @@ pub fn tokenize(input: &String) -> Vec<Token> {
             '-' => {
                 push_text(&mut text, &mut result);
                 result.push(Token::RangeSeparator)
+            }
+            '\\' =>{
+                push_text(&mut text, &mut result);
+                result.push(Token::Delimiters)
             }
             a => {
                 text.push(a);


### PR DESCRIPTION
Added delimiters to parsing. Now a user can pass "shift + \+" or "\+ + \-" and have the tokens be abbreviated.
